### PR TITLE
Copy tweaks

### DIFF
--- a/src/events.html
+++ b/src/events.html
@@ -58,7 +58,7 @@
     <section>
       <div class="content text-section">
         <h2 class="section-heading">Our Events</h2>
-        <p>We run regular events across London. Coding workshops, social mixers, project pitches from non-profit organisation and hackathons. Come say hello at one of our next events.</p>
+        <p>We run regular events across London. Coding workshops, social mixers, project pitches from non-profit organisations, tech talks and hackathons. Come say hello at one of our next events.</p>
         <a href="http://www.meetup.com/Women-Hack-For-Non-Profits/" class="button">Join us on Meetup</a>
       </div>
     </section>

--- a/src/faq.html
+++ b/src/faq.html
@@ -58,7 +58,7 @@
     </section>
     <section>
       <div class="faq">
-        <h2 class="section-heading">Volunteers: Frequently Asked Question</h2>
+        <h2 class="section-heading">Frequently Asked Questions: Volunteers</h2>
         <h3>1. How much time should I dedicate?</h3>
         <p>We understand that our volunteers are contributing their spare time and that lives can get busy. Any time you can dedicate, whether it be a couple of hours or a couple of days a week, will be beneficial and highly appreciated. Commitment differs between projects, teams and skillsets, so have a chat with us to see where you’d best fit.</p>
         <h3>2. Is this program restricted to only women?</h3>
@@ -80,26 +80,26 @@
           </ul>
         </p>
         <h3>4. How do I get started on a project? </h3>
-        <p>Once you sign up using this form , we will email you on how to get started. Once you’re all set up, you can browse through the projects and keep an eye on their progress via slack channels, JIRA and other comms. If you find a project you’d like to actively get involved in, get in touch with the Project Manager for that team. This can be done by introducing yourself in the project team’s slack channel or contacting us directly by email to discuss your interest.</p>
+        <p>Once you sign up using this form, we will email you on how to get started. Once you’re all set up, you can browse through the projects and keep an eye on their progress via slack channels, JIRA and other comms. If you find a project you’d like to actively get involved in, get in touch with the Project Manager for that team. This can be done by introducing yourself in the project team’s slack channel or contacting us directly by email to discuss your interest.</p>
         <h3>5. I’m new to coding/technology or returning after a long time - can I still join this group?</h3>
         <p>Yes, of course! One of our key goals is to aid the development of coding and technical skills within WHFNP. We have built a community that prides itself on supporting each other through sharing resources, providing workshops and simply helping each other out while we collaborate. Choose your project, tell your team that you are a “newbie” or “rusty” (a lot of us are!) and they’ll be more than happy to help. All you need to join is a passion for technology, open source and making great projects happen.</p>
       </div>
     </section>
     <section>
       <div class="faq">
-        <h2 class="section-heading">Non-Profits: Frequently Asked Question</h2>
+        <h2 class="section-heading">Frequently Asked Questions: Non-Profits</h2>
         <h3>1. When will development on my project begin and finish? We would like to go live in 3 months. Is that possible?</h3>
-        <p>We cannot commit on a timeline and it is very difficult to estimate or have a end time estimate upfront because most of the volunteers undertake this work along with their full time job. We advise that this is decided after you have sat with volunteers, discussed scope of work.</p>
-        <h3>2. Will you be able to do SEO, Social Marketing for us? </h3>
-        <p>We might be able to help decide on the social media strategy but this is not something we specialise in. Most of us are developers, UI/UX specialists and Quality Engineers. </p>
+        <p>Due to the nature of volunteer work, we cannot commit to a hard deadline or estimate delivery date upfront. Most of our volunteers undertake this work alongside their full time jobs. To achieve success in this context, our self-organized teams apply well-proven project management techniques to identify microtasks and deliver as efficiently as possible given each volunteer's availability. We advise that time expectations and any broken down deliverables are discussed after you have sat with volunteers and discussed the scope of work involved.</p>
+        <h3>2. Will you be able to help us with marketing strategies (e.g. SEO, social media)?</h3>
+        <p>We are happy to hear your requirements. However, our community is mostly made up of developers, UI/UX specialists and Quality Assurance engineers. We currently don't have a large number of volunteers that hold expertise in social marketing.</p>
         <h3>3. I have a very good idea that can change the world but I don’t know where to begin. Can I come and present my thoughts? Do I need to have technical spec prepared before pitching? </h3>
-        <p>Yes, after you submit the form, we will then contact you asking for more details about the project. You will need to have scope/details of the project in writing that you would like to pitch before volunteers. Once we run this via our group internally, we will then contact you and arrange for you to come and present to one of our meetup. We will then run call for volunteers internally. Within 2-4 weeks, we will be able to connect you with volunteers who have expressed interest in working on the project. However, this is totally dependent on volunteers.</p>
+        <p>Yes, after you submit the form, we will then contact you asking for more details about the project. You will need to have the scope/details of the project in writing outlining what you wll be pitching to volunteers. Once we run this via our group internally, we will then contact you and arrange for you to come and present at one of our monthly meetups. Depending on the stage of your project, we will then run call for volunteers internally or gather feedback of how you can further break down your project into a deliverable that's within scope. You should receive feedback on this outcome within 2-4 weeks. Please note we do not continue to run call on projects after this initial phase so it is highly dependent on volunteers expressing their interest or opening discussion after your pitch to gauge whether or not we can provide assistance.</p>
         <h3>4. Can I get access to Slack which is where I was told all the volunteers communicate?</h3>
-        <p>Unfortunately No. We use Slack to communicate amongst ourselves. Sometimes conversation there can be confidential. </p>
+        <p>We do not openly allow groups or individuals to join our Slack community unless they are a registered volunteer or a non profit/individual working on active projects with our teams.</p>
         <h3>5. What are WHFNP terms and conditions? </h3>
-        <p>That the code produced by WHFNP volunteers is open source. That the web/mobile applications have mention of WHFNP (please ask us for media kit). That we and our volunteers are respected for the contribution they are making and treated fairly. </p>
+        <p>Any projects produced in collaboration with WHFNP require that: a) The code produced by WHFNP volunteers is <a href="https://opensource.com/resources/what-open-source" class="text-link">open source</a>, b) The digital solutions built attribute WHFNP (please ask us for media kit), c) A dedicated contact is provided with ample availability for requirements consultation, to provide direction and to help our volunteers deliver the end product efficiently, d) Our volunteers are respected for the contribution they are making and treated professionally and fairly.</p>
         <h3>6. Do we have to pay for the services? </h3>
-        <p>We are volunteering our time free of cost to help charities world wide overcome their technology challenges/barriers. Which means that even though we are not charging for our services at this point of time, we do expect that charities treats us with respect and abide to terms and conditions mentioned above. </p>
+        <p>We are volunteering our time free of cost to help charities worldwide overcome their technology challenges/barriers. Though we are not charging for our services at this point of time, we do expect that charities treat our organisation and its volunteers professionally, respecting their time and effort and abiding to the terms and conditions mentioned above.</p>
       </div>
     </section>
     <section>

--- a/src/index.html
+++ b/src/index.html
@@ -62,11 +62,11 @@
         <div class="col-wrap">
           <div class="col-3 who-we-are">
             <h2>Women in Tech</h2>
-            <p>We are women from all sorts of backgrounds - coders, designers, testers, project managers, writers and many more. The thread that unites us is an interest and passion for technology.</p>
+            <p>We are women from all sorts of professional backgrounds: coders, designers, testers, project managers, writers and many more. We are a diverse mix of cultures, ages and experiences. The thread that unites us is an interest and passion for technology.</p>
           </div>
           <div class="col-3 who-we-are">
             <h2>Community-Driven</h2>
-            <p>We &#9829; Open Source, collaboration and knowledge-sharing. Through <a href="https://github.com/womenhackfornonprofits/" class="text-link">open source code</a>, tech events, blog posts and learning aid we encourage more women to contribute to the community and increase their technical footprint.</p>
+            <p>We &#9829; Open Source, collaboration and knowledge-sharing. Through <a href="https://github.com/womenhackfornonprofits/" class="text-link">open source code</a>, tech events, blog posts and learning aids we encourage more women to contribute to the community and increase their technical footprint.</p>
           </div>
           <div class="col-3 who-we-are">
             <h2>Matchmakers</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -65,12 +65,12 @@
             <p>We are women from all sorts of backgrounds - coders, designers, testers, project managers, writers and many more. The thread that unites us is an interest and passion for technology.</p>
           </div>
           <div class="col-3 who-we-are">
-            <h2>Open Source</h2>
-            <p> We &#9829; Open Source. We try to keep our <a href="https://github.com/womenhackfornonprofits/" class="text-link">code open source</a>, encouraging more women to contribute to the community and increase their open source footprint.</p>
+            <h2>Community-Driven</h2>
+            <p>We &#9829; Open Source, collaboration and knowledge-sharing. Through <a href="https://github.com/womenhackfornonprofits/" class="text-link">open source code</a>, tech events, blog posts and learning aid we encourage more women to contribute to the community and increase their technical footprint.</p>
           </div>
           <div class="col-3 who-we-are">
-            <h2>Our Mission</h2>
-            <p>We aim to enhance the skill set of women in tech to support their growth and increase their footprint in the open source community. Come say “hello” at our next <a href="http://www.meetup.com/Women-Hack-For-Non-Profits/events/" class="text-link">meetup!</a></p>
+            <h2>Matchmakers</h2>
+            <p>We link passionate women in tech to meaningful projects, providing them with a supportive environment to exercise their skills and pride themselves in creating solutions that give something back. Come see what we're all about at our next <a href="http://www.meetup.com/Women-Hack-For-Non-Profits/events/" class="text-link">meetup!</a></p>
           </div>
         </div>
       </div>
@@ -78,7 +78,7 @@
     <section>
       <div class="content text-section">
         <h2 class="section-heading"> Volunteers </h2>
-        <p> Are you interested in volunteering with us? We are always looking for passionate volunteers with all types of skills. Whether you enjoy coding, testing, technical operations, managing teams, getting creative or whatever your forte, we welcome your time and effort to help make our projects happen.I n return, we provide you with a supportive environment to practice your skills and pick up new ones with ongoing workshops and tech events. <a href="meet-the-volunteers.html" class="text-link"> Meet some of our volunteers</a> to find out what you could be both contributing and learning by joining WHFNP.
+        <p> Are you interested in volunteering with us? We are always looking for passionate volunteers with all types of skills. Whether you enjoy coding, testing, technical operations, managing teams, getting creative or whatever your forte, we welcome your time and effort to help make our projects happen. In return, we provide you with a supportive environment to practice your skills and pick up new ones with ongoing workshops and tech events. <a href="meet-the-volunteers.html" class="text-link"> Meet some of our volunteers</a> to find out what you could be both contributing and learning by joining WHFNP.
         </p>
         <a href="volunteers.html" class="button">How to volunteer</a>
       </div>

--- a/src/non-profits.html
+++ b/src/non-profits.html
@@ -73,7 +73,7 @@
               <img class="non-profit-icons" src="img/icons/email-confirmation.svg" alt="Email Confirmation Image">
             </div>
             <h2 class="section-heading">2. Confirmation</h2>
-            <p>We will send you a confirmation email and get in touch to discuss your submition in more detail.</p>
+            <p>We will send you a confirmation email and get in touch to discuss your submission in more detail.</p>
           </div>
           <div class="col-3">
             <div class="">


### PR DESCRIPTION
### Description

Some content tweaks for sections: Homepage, Non Profits, Events, FAQ.

**_Progress: 100%**_

---
### Tasks
- [x] Update headings on homepage under **Who We Are** so it reads better as descriptions of who our org is. Was: `Women In Tech / Open Source / Our Mission`. Now: `Women In Tech / Community-Driven / Matchmakers`. 
- [x] Update copy across the content pages, fixing typos and improving wording so it's clear and more specific to the revised WHFNP mission
### Screengrabs

![screen shot 2016-02-09 at 00 02 47](https://cloud.githubusercontent.com/assets/574526/12903563/7fb1fb0c-cec0-11e5-8824-bdc10e2031aa.png)
