### PR TITLE
center project background images

### DIFF
--- a/src/sass/partials/_projects.scss
+++ b/src/sass/partials/_projects.scss
@@ -15,32 +15,32 @@
 }
 
 .findacure {
-	background: url('../img/non-profits/findacure.png') no-repeat;
+	background: url('../img/non-profits/findacure.png') no-repeat center center;
 	background-size: cover;
 }
 
 .fashrevwall {
-	background: url('../img/non-profits/fashrevwall.png') no-repeat;
+	background: url('../img/non-profits/fashrevwall.png') no-repeat center center;
 	background-size: cover;
 }
 
 .whfnp {
-	background: url('../img/non-profits/whfnp.png') no-repeat;
+	background: url('../img/non-profits/whfnp.png') no-repeat center center;
 	background-size: cover;
 }
 
 .ippr {
-	background: url('../img/non-profits/IPPR.png') no-repeat;
+	background: url('../img/non-profits/IPPR.png') no-repeat center center;
 	background-size: cover;
 }
 
 .pimpmycause {
-	background: url('../img/non-profits/pimpmycause.png') no-repeat;
+	background: url('../img/non-profits/pimpmycause.png') no-repeat center center;
 	background-size: cover;
 }
 
 .jaspalsvoice {
-	background: url('../img/non-profits/jaspalsvoice.png') no-repeat;
+	background: url('../img/non-profits/jaspalsvoice.png') no-repeat center center;
 	background-size: cover;
 }
 


### PR DESCRIPTION
@womenhackfornonprofits/whfnp
## Linked Jira/Github Issue Ticket

Issue #131 
## What are the changes included in this PR?

Centered the background project images. There is not much difference except the image stays centered as the screen size gets smaller and crops from the left and right side of the image rather than just the right side of the the image. This responsive issue will be fully resolved when the page is updated to bootstrap.
## If the changes are visual, provide a screenshot.

![issue-131](https://cloud.githubusercontent.com/assets/20387843/19024966/5bd98724-8908-11e6-89c0-b1db2575a01e.jpg)
